### PR TITLE
Encode URL to allow for use with indices

### DIFF
--- a/lib/yahoo_stock/interface.rb
+++ b/lib/yahoo_stock/interface.rb
@@ -37,7 +37,7 @@ module YahooStock
       return @base_url if @uri_parameters.nil? || @uri_parameters.empty?
       params_with_values = []
       @uri_parameters.each {|k,v| params_with_values << "#{k}=#{v}"}
-      @base_url+'?'+params_with_values.join('&')
+      URI.encode(@base_url+'?'+params_with_values.join('&'))
     end
     
     # Get result string

--- a/spec/yahoo_stock/interface_spec.rb
+++ b/spec/yahoo_stock/interface_spec.rb
@@ -24,6 +24,14 @@ describe YahooStock::Interface do
       @interface.uri.should =~ /f=toom/
       @interface.uri.should =~ /k=zoom/
     end
+
+    it "should encode carrot (^) symbols for market indices" do
+      @interface.uri_parameters = {:s => '^boom', :f => 'toom', :k => 'zoom'}
+      @interface.uri.should =~ /http:\/\/download.finance.yaaaaahoo.com\/d\/quotes.csv?/
+      @interface.uri.should =~ /s=%5Eboom/
+      @interface.uri.should =~ /f=toom/
+      @interface.uri.should =~ /k=zoom/
+    end
   end
   
   describe "get" do


### PR DESCRIPTION
Yahoo indices use carrot(^) symbol which is currently not being ASCII
encoded.  URI.parse throws an error with unencoded carrots.

This commit encodes the entire URL so that this can be used with Yahoo
indices.  Spec test included.
